### PR TITLE
Show all ong's or message

### DIFF
--- a/app/views/ongs/index.html.erb
+++ b/app/views/ongs/index.html.erb
@@ -4,25 +4,29 @@
     </div>
 </div>
 <div class="col_none">
-  <% @ongs.each do |ong| %>
-    <div class="banco">
-      <div class="ficha_banco">
-        <div class="bar-main-container">
-          <div class="campania">Septiembre 2014</div><div class="faltandias">20</div>
-          <div class="bar-container">
-            <div class="objetivo">300</div>
-            <div class="bar" style="width: 70%;"><div>70%</div></div>
-            <div class="registrados">210</div>
+  <% if @ongs.present? %>
+    <% @ongs.each do |ong| %>
+      <div class="banco">
+        <div class="ficha_banco">
+          <div class="bar-main-container">
+            <div class="campania">Septiembre 2014</div><div class="faltandias">20</div>
+            <div class="bar-container">
+              <div class="objetivo">300</div>
+              <div class="bar" style="width: 70%;"><div>70%</div></div>
+              <div class="registrados">210</div>
+            </div>
           </div>
+          <p><%= ong.phone %> - <%= ong.adminEmail %></p>
+          <p><%= ong.websiteUrl %> - <%= ong.facebookPage %></p>
+          <div class="reservar"><%= link_to "Donar aquí", new_ong_booking_path(ong) %></div>
         </div>
-        <p><%= ong.phone %> - <%= ong.adminEmail %></p>
-        <p><%= ong.websiteUrl %> - <%= ong.facebookPage %></p>
-        <div class="reservar"><%= link_to "Donar aquí", new_ong_booking_path(ong) %></div>
+        <h3><%= ong.name %></h3>
+        <h2><%= ong.address %>,<br/><%= ong.address2 %></h2>
+        <h4>c.p. <%= ong.zip %>. <%= ong.city %>, <%= ong.state %>, <%= ong.country_id %>.</h4>
+        <div style="clear:both;"></div>
       </div>
-      <h3><%= ong.name %></h3>
-      <h2><%= ong.address %>,<br/><%= ong.address2 %></h2>
-      <h4>c.p. <%= ong.zip %>. <%= ong.city %>, <%= ong.state %>, <%= ong.country_id %>.</h4>
-      <div style="clear:both;"></div>
-    </div>
+    <% end %>
+  <% else %>
+    <h2 class="text-center">There are no ong registered</h2>
   <% end %>
 </div>


### PR DESCRIPTION
On click to the image icon(as mention) it redirects to the ong's index page where it will show all the ong's(not only of current user) and in case if their is no ong registered, then it will show message their.
Msg is not visible due to css issue on the page.